### PR TITLE
Fix listSeriesGroup & createSeriesGroup methods

### DIFF
--- a/src/resources/organizations.ts
+++ b/src/resources/organizations.ts
@@ -201,7 +201,7 @@ export default class Organizations {
    */
   listSeriesGroup(organization_id: string) {
     return this.client
-      .get('/organizations/' + organization_id + 'series-group')
+      .get('/organizations/' + organization_id + '/series-group')
       .then((r) => r.data);
   }
 
@@ -213,7 +213,7 @@ export default class Organizations {
    */
   createSeriesGroup(organization_id: string, seriesData: Series) {
     return this.client
-      .post('/organizations/' + organization_id + 'series-group', seriesData)
+      .post('/organizations/' + organization_id + '/series-group', seriesData)
       .then((r) => r.data);
   }
 


### PR DESCRIPTION
There is currently an issue with the way the `listSeriesGroup` and `createSeriesGroup` methods are implemented.

Both are not taking into account the `/` that's missing when forming the URL for the facturapi API, thus always returning a "Bad Organization Id" response.