### PR TITLE
Expose cancellation motive to be used easily

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -80,6 +80,10 @@ export default class Facturapi {
     return enums.InvoiceStatus;
   }
 
+  static get CancellationMotive() {
+    return enums.CancellationMotive;
+  }
+
   constructor(apiKey: string, options: FacturapiOptions = {}) {
     if (options.apiVersion) {
       if (!VALID_API_VERSIONS.includes(options.apiVersion)) {


### PR DESCRIPTION
The main reason for this Pull Request is to be able to use the enum for the cancellation motive in the same way as the rest are used, without needing to know the values or replicate the enum in the place where an invoice needs to be canceled.

Example of how it can be used from now on:
```
import Facturapi from 'facturapi’
await facturapi.invoices.cancel(invoiceId, { motive: Facturapi.CancellationMotive.NO_SE_CONCRETO })
```