### PR TITLE
Agrega CancellationStatus verifying

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [4.13.0] 2026-02-06
+
+### Added
+
+- Add `CancellationStatus.VERIFYING` (`"verifying"`) to support SAT cancellation requests in verification.
+
 ## [4.12.0] 2026-01-21
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "facturapi",
-  "version": "4.11.0",
+  "version": "4.13.0",
   "description": "Librería oficial de Facturapi. Crea CFDIs timbrados y enviados al SAT, XML y PDF",
   "main": "dist/index.cjs.js",
   "module": "dist/index.es.js",

--- a/src/enums.ts
+++ b/src/enums.ts
@@ -172,6 +172,7 @@ export enum CancellationStatus {
   NONE = 'none',
   ACCEPTED = 'accepted',
   PENDING = 'pending',
+  VERIFYING = 'verifying',
   REJECTED = 'rejected',
   EXPIRED = 'expired',
 }


### PR DESCRIPTION
This pull request introduces a new cancellation status to support SAT cancellation requests that are in the verification stage. The version is also bumped to 4.13.0. The most important changes are:

New Feature: SAT Cancellation Verification Support

* Added `CancellationStatus.VERIFYING` (`"verifying"`) to the `CancellationStatus` enum to represent cancellation requests that are currently being verified by SAT. [[1]](diffhunk://#diff-00310f3f832445de900d07b99183266cabc84aa21246ec7f1d136635b3108f79R175) [[2]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR8-R13)

Versioning

* Updated the package version to `4.13.0` in `package.json` to reflect the new feature addition.
* Documented the new version and feature in `CHANGELOG.md`.