### PR TITLE
Include rfc provider cert in the stamp type

### DIFF
--- a/src/types/invoice.ts
+++ b/src/types/invoice.ts
@@ -66,6 +66,7 @@ export interface Invoice {
     sat_cert_number: string;
     signature: string;
     complement_string: string;
+    rfc_provider_cert: string;
   } | null;
   addenda?: string | null;
   conditions: string | null;


### PR DESCRIPTION
With this pull request I'm trying to fix this issue:
https://github.com/FacturAPI/facturapi-node/issues/84

The main objective is to have these fields available to be printed in the invoice.