### PR TITLE
fix(deploy): restore npm OIDC trusted publishing

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -21,9 +21,7 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: "24"
-
-      - name: Pin npm version
-        run: npm i -g npm@10.9.2
+          registry-url: "https://registry.npmjs.org"
 
       - name: Install dependencies
         run: npm ci


### PR DESCRIPTION
## Summary
- remove the `npm@10.9.2` pin from deploy workflow
- keep Node 24 npm for publish, which supports trusted publishing/OIDC flow
- set explicit npm registry URL in setup-node

## Why
Latest deploy to `main` failed with `ENEEDAUTH` during `npm publish --provenance`.
This happened after pinning npm 10 in deploy; removing that pin restores the expected OIDC trusted publishing behavior.
