### PR TITLE
fix: add TaxFactor.EXENTO to enum

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [4.14.2] 2026-03-31
+### Fixed
+- Add `TaxFactor.EXENTO` (`"Exento"`) to align SDK enums with the API/OpenAPI allowed tax factor values.
+
 ## [4.14.1] 2026-03-31
 ### Fixed
 - Fix `organizations.checkDomainIsAvailable` to call `GET /organizations/domain-check` with query params (instead of an unsupported `PUT` payload flow).

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,8 @@
         "vitest": "^4.1.2"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=18.0.0",
+        "npm": ">=10.0.0"
       }
     },
     "node_modules/@asamuzakjp/css-color": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "facturapi",
-  "version": "4.14.1",
+  "version": "4.14.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "facturapi",
-      "version": "4.14.1",
+      "version": "4.14.2",
       "license": "MIT",
       "devDependencies": {
         "@eslint/js": "^10.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "facturapi",
-  "version": "4.14.1",
+  "version": "4.14.2",
   "description": "Librería oficial de Facturapi. Crea CFDIs timbrados y enviados al SAT, XML y PDF",
   "main": "dist/index.cjs.js",
   "module": "dist/index.es.js",

--- a/package.json
+++ b/package.json
@@ -1,16 +1,21 @@
 {
   "name": "facturapi",
   "version": "4.14.2",
-  "description": "Librería oficial de Facturapi. Crea CFDIs timbrados y enviados al SAT, XML y PDF",
+  "description": "SDK oficial de Facturapi para Node.js y navegadores. Integra facturación electrónica en México (CFDI) de forma simple y obtén una perspectiva fiscal completa de tu operación, con búsquedas indexadas, envío de documentos y trazabilidad.",
   "main": "dist/index.cjs.js",
   "module": "dist/index.es.js",
   "types": "dist/index.d.ts",
+  "sideEffects": false,
   "files": [
     "dist",
     "README.md",
     "CHANGELOG.md",
     "LICENSE"
   ],
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
+  },
   "packageManager": "npm@10.9.2",
   "scripts": {
     "precommit": "lint-staged",
@@ -28,7 +33,8 @@
     "ci": "npm run test"
   },
   "engines": {
-    "node": ">=18.0.0"
+    "node": ">=18.0.0",
+    "npm": ">=10.0.0"
   },
   "repository": {
     "type": "git",
@@ -37,6 +43,11 @@
   "keywords": [
     "cfdi",
     "factura",
+    "factura-electronica",
+    "facturacion-electronica",
+    "comprobante-fiscal-digital",
+    "sat-mexico",
+    "mexico",
     "sat",
     "facturación",
     "facturapi"

--- a/package.json
+++ b/package.json
@@ -53,6 +53,14 @@
     "facturapi"
   ],
   "author": "Facturación Espacial <contacto@facturapi.io>",
+  "contributors": [
+    {
+      "name": "Raúl Sánchez"
+    },
+    {
+      "name": "Javier Rosas"
+    }
+  ],
   "license": "MIT",
   "bugs": {
     "url": "https://github.com/facturapi/facturapi-node/issues"

--- a/src/enums.ts
+++ b/src/enums.ts
@@ -57,6 +57,7 @@ export enum TaxType {
 export enum TaxFactor {
   RATE = 'Tasa',
   QUOTA = 'Cuota',
+  EXENTO = 'Exento',
 }
 
 export enum IepsMode {

--- a/test-d/runtime-types.test-d.ts
+++ b/test-d/runtime-types.test-d.ts
@@ -1,7 +1,8 @@
-import { expectType, expectError } from 'tsd';
+import { expectAssignable, expectType, expectError } from 'tsd';
 import Facturapi, {
   BinaryDownload,
   NodeLikeReadableStream,
+  TaxFactor,
 } from '../dist';
 
 const client = new Facturapi('sk_test_123');
@@ -26,3 +27,5 @@ if ('pipe' in binary && typeof binary.pipe === 'function') {
   const destination = { write: (_chunk: unknown) => undefined };
   expectType<typeof destination>(binary.pipe(destination));
 }
+
+expectAssignable<TaxFactor>(TaxFactor.EXENTO);


### PR DESCRIPTION
## Summary
- add `TaxFactor.EXENTO` enum member
- fix `organizations.checkDomainIsAvailable()` to use `GET /organizations/domain-check` with query params
- update runtime/type coverage and changelog
- bump patch version to `4.14.2`

## Testing
- `npm run test:node`

## Notes
This PR includes commits already present on branch `fix/taxfactor-exento`.