### PR TITLE
feat(invoices): agregar métodos ZIP y cuentas prediales

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## Unreleased
+## [4.20.0] 2026-08-21
 
 ### Added
 
 - Add invoice ZIP request methods: `invoices.createZipRequest`, `invoices.listZipRequests`, `invoices.retrieveZipRequest`, and `invoices.downloadZipRequest`.
+
+### Fixed
+
+- Type `property_tax_account` as an array in invoice and receipt responses.
 
 ## [4.19.0] 2026-07-01
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "facturapi",
-  "version": "4.19.0",
+  "version": "4.20.0",
   "description": "SDK oficial de Facturapi para Node.js y navegadores. Integra facturación electrónica en México (CFDI) de forma simple y obtén una perspectiva fiscal completa de tu operación, con búsquedas indexadas, envío de documentos y trazabilidad.",
   "main": "dist/index.cjs.js",
   "module": "dist/index.es.js",

--- a/src/types/common.ts
+++ b/src/types/common.ts
@@ -86,7 +86,7 @@ export interface InvoiceItem {
   third_party: InvoiceItemThirdParty;
   complement: string;
   parts: InvoiceItemPart[];
-  property_tax_account: string;
+  property_tax_account: string[];
 }
 
 export interface XmlNamespace {

--- a/test-d/runtime-types.test-d.ts
+++ b/test-d/runtime-types.test-d.ts
@@ -2,6 +2,7 @@ import { expectAssignable, expectType, expectError } from 'tsd';
 import Facturapi, {
   BinaryDownload,
   FacturapiError,
+  InvoiceItem,
   InvoiceType,
   IssuingType,
   NodeLikeReadableStream,
@@ -58,6 +59,9 @@ if ('pipe' in binary && typeof binary.pipe === 'function') {
 }
 
 expectAssignable<TaxFactor>(TaxFactor.EXENTO);
+
+declare const invoiceItem: InvoiceItem;
+expectType<string[]>(invoiceItem.property_tax_account);
 
 declare const apiError: FacturapiError;
 expectType<number>(apiError.status);


### PR DESCRIPTION
## Objetivo

Publicar la siguiente versión del SDK con los métodos para solicitar archivos ZIP y el tipo correcto para cuentas prediales.

## Cambios

- Agrega métodos para solicitar ZIP de facturas y retenciones.
- Modela `property_tax_account` como arreglo, conforme al CFDI.
- Publica la versión `4.20.0`.

## Verificación

- `pnpm test`